### PR TITLE
FOGL-1979: set_filter_config method can be omitted in python script

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -226,11 +226,6 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 		return NULL;
 	}
 
-	/**
-	 * We now pass the filter JSON configuration to the loaded module
-	 */
-	// Set configuration object	
-	PyObject* pConfig = PyDict_New();
 	// Whole configuration as it is
 	string filterConfiguration;
 
@@ -245,43 +240,66 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 		filterConfiguration = "{}";
 	}
 
-	// Add JSON configuration, as string, to "config" key
-	PyObject* pConfigObject = PyUnicode_DecodeFSDefault(filterConfiguration.c_str());
-	PyDict_SetItemString(pConfig,
-			     "config",
-			     pConfigObject);
-	Py_CLEAR(pConfigObject);
-
 	/**
-	 * Call method set_filter_config(c)
-	 * This creates a global JSON configuration
-	 * which will be available when fitering data with "plugin_ingest"
-	 *
-	 * set_filter_config(config) returns 'True'
+	 * We now pass the filter JSON configuration to the loaded module
 	 */
-	PyObject* pSetConfig = PyObject_CallMethod(pModule,
-						   (char *)string(DEFAULT_FILTER_CONFIG_METHOD).c_str(),
-						   (char *)string("O").c_str(),
-						   pConfig);
-	// Check result
-	if (!pSetConfig ||
-	    !PyBool_Check(pSetConfig) ||
-	    !PyLong_AsLong(pSetConfig))
+	PyObject* pConfigFunc = PyObject_GetAttrString(pModule,
+						       (char *)string(DEFAULT_FILTER_CONFIG_METHOD).c_str());
+	// Check whether "set_filter_config" method exists
+	if (PyCallable_Check(pConfigFunc))
 	{
-		logErrorMessage();
+		// Set configuration object	
+		PyObject* pConfig = PyDict_New();
+		// Add JSON configuration, as string, to "config" key
+		PyObject* pConfigObject = PyUnicode_DecodeFSDefault(filterConfiguration.c_str());
+		PyDict_SetItemString(pConfig,
+				     "config",
+				     pConfigObject);
+		Py_CLEAR(pConfigObject);
+		/**
+		 * Call method set_filter_config(c)
+		 * This creates a global JSON configuration
+		 * which will be available when fitering data with "plugin_ingest"
+		 *
+		 * set_filter_config(config) returns 'True'
+		 */
+		//PyObject* pSetConfig = PyObject_CallMethod(pModule,
+		PyObject* pSetConfig = PyObject_CallFunctionObjArgs(pConfigFunc,
+								    // arg 1
+								    pConfig,
+								    // end of args
+								    NULL);
+		// Check result
+		if (!pSetConfig ||
+		    !PyBool_Check(pSetConfig) ||
+		    !PyLong_AsLong(pSetConfig))
+		{
+			logErrorMessage();
 
-		Py_CLEAR(pModule);
-		Py_CLEAR(pFunc);
+			Py_CLEAR(pModule);
+			Py_CLEAR(pFunc);
+			// Remove temp objects
+			Py_CLEAR(pConfig);
+			Py_CLEAR(pSetConfig);
+
+			// Remove function object
+			Py_CLEAR(pConfigFunc);
+
+			return NULL;
+		}
+		// Remove call object
+		Py_CLEAR(pSetConfig);
 		// Remove temp objects
 		Py_CLEAR(pConfig);
-		Py_CLEAR(pSetConfig);
-
-		return NULL;
+	}
+	else
+	{
+		// Reset error if config function is not present
+		PyErr_Clear();
 	}
 
-	// Remove temp objects
-	Py_CLEAR(pSetConfig);
-	Py_CLEAR(pConfig);
+	// Remove function object
+	Py_CLEAR(pConfigFunc);
 
 	// Return filter handle
 	return (PLUGIN_HANDLE)handle;
@@ -461,9 +479,12 @@ static PyObject* createReadingsList(const vector<Reading *>& readings)
 			}
 
 			// Add Datapoint: key and value
-			PyDict_SetItemString(newDataPoints,
-					     (*it)->getName().c_str(),
-					     value);
+			PyObject* key = PyBytes_FromString((*it)->getName().c_str());
+			PyDict_SetItem(newDataPoints,
+					key,
+					value);
+			
+			Py_CLEAR(key);
 			Py_CLEAR(value);
 		}
 

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -23,8 +23,11 @@
 #include <Python.h>
 
 // Relative path to FOGLAMP_DATA
-#define PYTHON_FILTERS_PATH "/filters"
+#define PYTHON_FILTERS_PATH "/scripts"
 #define FILTER_NAME "python35"
+#define PYTHON_SCRIPT_METHOD_PREFIX "_script_"
+#define PYTHON_SCRIPT_FILENAME_EXTENSION ".py"
+#define SCRIPT_CONFIG_ITEM_NAME "script"
 
 /**
  * The Python 3.5 script module to load is set in
@@ -66,7 +69,7 @@
 				"\"type\" : \"JSON\", " \
 				"\"default\" : {}}, " \
 			"\"script\" : {\"description\" : \"Python 3.5 module to load.\", " \
-				"\"type\": \"string\", " \
+				"\"type\": \"script\", " \
 				"\"default\": \"""\"} }"
 using namespace std;
 
@@ -131,15 +134,30 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 						  outHandle,
 						  output);
 
+	pythonScript = string("");
+
 	// Check whether we have a Python 3.5 script file to import
-	if (handle->getConfig().itemExists("script"))
+	if (handle->getConfig().itemExists(SCRIPT_CONFIG_ITEM_NAME))
 	{
-		pythonScript = handle->getConfig().getValue("script");
+		try
+		{
+			// Get Python script file from "file" attibute of "scipt" item
+			pythonScript = handle->getConfig().getItemAttribute(SCRIPT_CONFIG_ITEM_NAME,
+									    ConfigCategory::FILE_ATTR);
+		        // Just take file name and remove path
+			std::size_t found = pythonScript.find_last_of("/");
+			pythonScript = pythonScript.substr(found + 1);
+		}
+		catch (ConfigItemAttributeNotFound* e)
+		{
+			delete e;
+		}
+		catch (exception* e)
+		{
+			delete e;
+		}
 	}
-	else
-	{
-		pythonScript = string("");
-	}
+
 	if (pythonScript.empty())
 	{
 		// Do nothing
@@ -179,6 +197,25 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 	Py_CLEAR(pPath);
 
 	// Import script as module
+	// NOTE:
+	// Script file name is:
+	// lowercase(categoryName) + _script_ + methodName + ".py"
+
+	// 1) Get methodName
+	std::size_t found = pythonScript.rfind(PYTHON_SCRIPT_METHOD_PREFIX);
+	string filterMethod = pythonScript.substr(found + strlen(PYTHON_SCRIPT_METHOD_PREFIX));
+	// Remove .py from filterMethod
+	found = filterMethod.rfind(PYTHON_SCRIPT_FILENAME_EXTENSION);
+	filterMethod.replace(found,
+			     strlen(PYTHON_SCRIPT_FILENAME_EXTENSION),
+			     "");
+	// Remove .py from pythonScript
+	found = pythonScript.rfind(PYTHON_SCRIPT_FILENAME_EXTENSION);
+	pythonScript.replace(found,
+			     strlen(PYTHON_SCRIPT_FILENAME_EXTENSION),
+			     "");
+
+	// 2) Import Python script
 	pModule = PyImport_ImportModule(pythonScript.c_str());
 
 	// Check whether the Python module has been imported
@@ -190,7 +227,7 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 			logErrorMessage();
 		}
 		Logger::getLogger()->fatal("Filter '%s' (%s), cannot import Python 3.5 script "
-					   "'%s.py' from '%s'",
+					   "'%s' from '%s'",
 					   FILTER_NAME,
 					   handle->getConfig().getName().c_str(),
 					   pythonScript.c_str(),
@@ -200,13 +237,11 @@ PLUGIN_HANDLE plugin_init(ConfigCategory* config,
 		return NULL;
 	}
 
-	// NOTE:
-	// Filter method to call is the same as filter name
 	// Fetch filter method in loaded object
-	pFunc = PyObject_GetAttrString(pModule, pythonScript.c_str());
+	pFunc = PyObject_GetAttrString(pModule, filterMethod.c_str());
 
 	if (!PyCallable_Check(pFunc))
-        {
+	{
 		// Failure
 		if (PyErr_Occurred())
 		{


### PR DESCRIPTION
FOGL-1979: set_filter_config method can be omitted in python script.

This allows the writing of simple filters without configuration.

Small fix for "key" variable in PyDict_SetItem(), createReadingsList()