### PR TITLE
Addition of syslog logging in scale35 example

### DIFF
--- a/examples/scale35.py
+++ b/examples/scale35.py
@@ -12,6 +12,20 @@ __version__ = "${VERSION}"
 
 import sys
 import json
+import logging
+from logging.handlers import SysLogHandler
+import os
+
+# Log to syslog
+handler = SysLogHandler(address='/dev/log')
+formatter = logging.Formatter(fmt='FogLAMP[%(process)d] %(levelname)s: %(name)s: %(message)s')
+handler.setFormatter(formatter)
+# When embedded Python is in use sys.argv is not defined,
+logger = logging.getLogger(os.path.basename(__file__))
+
+# Set mininum log severity
+logger.setLevel(logging.DEBUG)
+logger.addHandler(handler)
 
 """
 Filter configuration set by set_filter_config(config)
@@ -51,7 +65,7 @@ Returns:
 True
 """
 def set_filter_config(configuration):
-    #print(configuration)
+    logger.debug("Config = " + str(configuration)) 
     global filter_config
     filter_config = json.loads(configuration['config'])
 
@@ -95,7 +109,7 @@ def scale35(readings):
 
     # Process input data
     for elem in readings:
-            #print("IN=" + str(elem))
+            logger.debug("IN=" + str(elem))
             reading = elem['reading']
 
             # Apply some changes: multiply datapoint values by scale and add offset
@@ -103,5 +117,5 @@ def scale35(readings):
                 newVal = reading[key] * scale + offset
                 reading[key] = newVal
 
-            #print("OUT=" + str(elem))
+            logger.debug("OUT=" + str(elem))
     return readings


### PR DESCRIPTION
Addition of syslog logging in scale35 example

Setting a south service RAND_A with Python35 filter PY35 and script scale35.py

Example of logging 

- Log of configuration, when plugin starts

`Jul  5 03:05:55 ubuntu16-server-virt FogLAMP[706] DEBUG: rand_a_py35_script_scale35.py: Config = {'config': '{"a":9}'}`

- Log on Input
`Jul  5 03:05:59 ubuntu16-server-virt FogLAMP[706] DEBUG: rand_a_py35_script_scale35.py: IN={'user_ts': 1562313956, 'reading': {b'random': 36}, 'id': 139827697926320, 'asset_code': b'RandomA', 'uuid': b'b787a8c4-9efb-11e9-9643-080027fdb261', 'ts': 1562313956}`

- Log on output
`Jul  5 03:05:59 ubuntu16-server-virt FogLAMP[706] DEBUG: rand_a_py35_script_scale35.py: OUT={'user_ts': 1562313956, 'reading': {b'random': 190}, 'id': 139827697926320, 'asset_code': b'RandomA', 'uuid': b'b787a8c4-9efb-11e9-9643-080027fdb261', 'ts': 1562313956}`